### PR TITLE
small optimization

### DIFF
--- a/lib/components/summaryBottomSheet.dart
+++ b/lib/components/summaryBottomSheet.dart
@@ -215,7 +215,7 @@ class _SummaryBottomSheetState extends State<SummaryBottomSheet> {
               ),
             ),
             SizedBox(
-              height: MediaQuery.of(context).size.height * 0.47,
+              height: MediaQuery.sizeOf(context).height * 0.47,
               width: double.infinity,
               child: ListView(
                 children: [


### PR DESCRIPTION
By calling MediaQuery.of(context).size/padding/orientation, the widget will rebuild when any of the MediaQuery properties change (less performant). By calling MediaQuery.sizeOf/paddingOf/orientationOf(context) the widget will rebuild **only** when the property changes, avoiding unnecessary rebuilds.