### PR TITLE
search on `onSubmit`

### DIFF
--- a/lib/components/searchBox.dart
+++ b/lib/components/searchBox.dart
@@ -53,6 +53,9 @@ class _SearchBoxState extends State<SearchBox> {
                 hintStyle: TextStyle(color: Colors.grey[700]),
                 border: InputBorder.none,
               ),
+              onSubmitted: (searchTerm) {
+                widget.searchFunction(resetPagination: true); 
+              },
             ),
           ),
           IconButton(


### PR DESCRIPTION
Search should happen on keyboard enter also

- Most people including me prefer doing it when we click on enter on our keyboard search should happen
- Default UI too when using on keyboard open for search has a "tick mark" which somehow feels like it says to submit but on clicking nothing happens until we click/press on search icon at top

**Change:**

Before:

https://github.com/user-attachments/assets/eca2f5f9-bc15-410c-8ade-80429064c6e4

After:

https://github.com/user-attachments/assets/d364236d-2ce8-441c-b733-9e2786603604

