### PR TITLE
LateX Support on titles & summary

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,9 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <application
         android:label="ScholArxiv"
         android:name="${applicationName}"
-        android:icon="@mipmap/launcher_icon">
+        android:icon="@mipmap/launcher_icon"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/lib/components/eachPaperCard.dart
+++ b/lib/components/eachPaperCard.dart
@@ -2,10 +2,16 @@
 import 'package:arxiv/components/idAndDate.dart';
 import 'package:arxiv/components/summaryBottomSheet.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_tex/flutter_tex.dart';
 import 'package:hive/hive.dart';
 import 'package:ionicons/ionicons.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:theme_provider/theme_provider.dart';
+
+bool containsLatex(String title) {
+  final latexRegex = RegExp(r'[$\\{}]');
+  return latexRegex.hasMatch(title);
+}
 
 class EachPaperCard extends StatefulWidget {
   const EachPaperCard({
@@ -98,6 +104,17 @@ class _EachPaperCardState extends State<EachPaperCard> {
 
   @override
   Widget build(BuildContext context) {
+    String title = widget.eachPaper["title"]
+        .toString()
+        .replaceAll(RegExp(r'\\n'), '')
+        .replaceAll(RegExp(r'\\ '), '');
+
+    if (containsLatex(title) == true) {
+      title = title.replaceAll(RegExp(r'\$ '), r' \) ');
+      title = title.replaceAll(RegExp(r' \$'), r' \( ');
+      title = title.replaceAll(r'$', r' \) ');
+    }
+
     return Container(
       margin: const EdgeInsets.only(
         left: 8.0,
@@ -140,16 +157,23 @@ class _EachPaperCardState extends State<EachPaperCard> {
             ),
             child: Container(
               padding: const EdgeInsets.only(bottom: 5.0),
-              child: Text(
-                widget.eachPaper["title"]
-                    .toString()
-                    .replaceAll(RegExp(r'\\n'), '')
-                    .replaceAll(RegExp(r'\\ '), ''),
-                style: const TextStyle(
-                  fontSize: 16.0,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
+              child: containsLatex(title)
+                  ? TeXView(
+                      child: TeXViewDocument(
+                        title,
+                        style: TeXViewStyle(
+                          textAlign: TeXViewTextAlign.left,
+                          fontStyle: TeXViewFontStyle(fontSize: 16, fontWeight: TeXViewFontWeight.bold),
+                        ),
+                      ),
+                    )
+                  : Text(
+                      title,
+                      style: const TextStyle(
+                        fontSize: 16.0,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
             ),
           ),
 

--- a/lib/components/summaryBottomSheet.dart
+++ b/lib/components/summaryBottomSheet.dart
@@ -2,9 +2,12 @@
 import 'package:arxiv/pages/fullScreenSummaryPage.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_tts/flutter_tts.dart';
+import 'package:flutter_tex/flutter_tex.dart';
 import 'package:hive/hive.dart';
 import 'package:ionicons/ionicons.dart';
 import 'package:theme_provider/theme_provider.dart';
+
+import 'package:arxiv/components/eachPaperCard.dart';
 
 class SummaryBottomSheet extends StatefulWidget {
   const SummaryBottomSheet({
@@ -94,6 +97,15 @@ class _SummaryBottomSheetState extends State<SummaryBottomSheet> {
 
   @override
   Widget build(BuildContext context) {
+    String summary = widget.paperData["summary"]
+        .trim()
+        .replaceAll(RegExp(r'\\n'), ' ')
+        .replaceAll(RegExp(r'\\'), '');
+    if (containsLatex(summary)) { 
+      summary = summary.replaceAll(RegExp(r'\$ '), r' \) ');
+      summary = summary.replaceAll(RegExp(r' \$'), r' \( ');
+      summary = summary.replaceAll(r'$', r' \) ');
+    }
     return Scaffold(
       backgroundColor: Colors.transparent,
       body: Container(
@@ -271,16 +283,31 @@ class _SummaryBottomSheetState extends State<SummaryBottomSheet> {
                         top: 10.0,
                         bottom: 100.0,
                       ),
-                      child: SelectableText(
-                        widget.paperData["summary"]
-                            .trim()
-                            .replaceAll(RegExp(r'\\n'), ' ')
-                            .replaceAll(RegExp(r'\\'), ''),
-                        style: const TextStyle(
-                          fontSize: 15.0,
-                        ),
-                      ),
-                    ),
+                      child: (containsLatex(summary)
+                          ? TeXView(
+                              child: TeXViewDocument(
+                                summary,
+                                style: TeXViewStyle(
+                                  contentColor: ThemeProvider.themeOf(context)
+                                      .data
+                                      .textTheme
+                                      .bodyLarge
+                                      ?.color,
+                                  textAlign: TeXViewTextAlign.left,
+                                  fontStyle: TeXViewFontStyle(
+                                    fontSize: 15,
+                                    fontWeight: TeXViewFontWeight.normal
+                              ),
+                            ),
+                          ),
+                        )
+                          : SelectableText(
+                              summary,
+                              style: const TextStyle(
+                                fontSize: 15.0,
+                              ),
+                            )
+                    )),
                   ],
                 ),
               ),

--- a/lib/pages/fullScreenSummaryPage.dart
+++ b/lib/pages/fullScreenSummaryPage.dart
@@ -2,8 +2,12 @@
 import 'package:flutter/material.dart';
 import 'package:ionicons/ionicons.dart';
 import 'package:flutter_tts/flutter_tts.dart';
+import 'package:flutter_tex/flutter_tex.dart';
+
 import 'package:hive/hive.dart';
 import 'package:theme_provider/theme_provider.dart';
+
+import 'package:arxiv/components/eachPaperCard.dart';
 
 class FullScreenSummaryPage extends StatefulWidget {
   const FullScreenSummaryPage({
@@ -93,6 +97,15 @@ class _FullScreenSummaryPageState extends State<FullScreenSummaryPage> {
 
   @override
   Widget build(BuildContext context) {
+    String summary = widget.paperData["summary"]
+        .trim()
+        .replaceAll(RegExp(r'\\n'), ' ')
+        .replaceAll(RegExp(r'\\'), '');
+    if (containsLatex(summary)) {
+      summary = summary.replaceAll(RegExp(r'\$ '), r' \) ');
+      summary = summary.replaceAll(RegExp(r' \$'), r' \( ');
+      summary = summary.replaceAll(r'$', r' \) ');
+    }
     return Scaffold(
       appBar: AppBar(
         title: const Text(
@@ -191,15 +204,30 @@ class _FullScreenSummaryPageState extends State<FullScreenSummaryPage> {
               left: 20.0,
               right: 20.0,
             ),
-            child: SelectableText(
-              widget.paperData["summary"]
-                  .trim()
-                  .replaceAll(RegExp(r'\\n'), ' ')
-                  .replaceAll(RegExp(r'\\'), ''),
-              style: const TextStyle(
-                fontSize: 17.0,
-              ),
-            ),
+            child: containsLatex(summary)
+                          ? TeXView(
+                              child: TeXViewDocument(
+                                summary,
+                                style: TeXViewStyle(
+                                  contentColor: ThemeProvider.themeOf(context)
+                                      .data
+                                      .textTheme
+                                      .bodyLarge
+                                      ?.color,
+                                  textAlign: TeXViewTextAlign.left,
+                                  fontStyle: TeXViewFontStyle(
+                                    fontSize: 17,
+                                    fontWeight: TeXViewFontWeight.normal
+                              ),
+                            ),
+                          ),
+                        )
+                          : SelectableText(
+                              summary,
+                              style: const TextStyle(
+                                fontSize: 17.0,
+                              ),
+                            ),
           ),
         ],
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
     liquid_pull_to_refresh: ^3.0.1
     flutter_tts: ^4.0.2
     theme_provider: ^0.6.0
+    flutter_tex: ^4.0.9
 
 dev_dependencies:
     flutter_test:


### PR DESCRIPTION
Closes #11 

At first I tried doing it directly like:

```dart
              child: TeXView(
                child: TeXViewDocument(
                  widget.eachPaper["title"]
                      .toString()
                      .replaceAll(RegExp(r'\\n'), '')
                      .replaceAll(RegExp(r'\\ '), ''),
                  style: TeXViewStyle(
                    textAlign: TeXViewTextAlign.left,
                    fontStyle: TeXViewFontStyle(fontSize: 16),
```

But this caused an issue i.e, it started rendering for every title which caused a lag, or you could say load of title became slower, so I decided to add a check for it then render only those title's which has LateX syntax in them, now it became much faster.


| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/866c68d7-c4a1-422a-be3f-1077dc260039) | ![image](https://github.com/user-attachments/assets/f6f4ca3b-eb90-43bb-b033-5a3df2d75a74) |
| ![image](https://github.com/user-attachments/assets/b4f3d3b2-2fcd-47c4-93d9-f56ef47fe1f1) | ![image](https://github.com/user-attachments/assets/b11cc863-97ad-4b1c-9180-dd49c149637e) |
| ![image](https://github.com/user-attachments/assets/50a18c4c-1442-4c4a-a5c9-e2d14b5327a0) | ![image](https://github.com/user-attachments/assets/ff2aa401-08dd-4e22-9ee7-0c5d2448765b) |
